### PR TITLE
fix(dependencies): Use dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ description = "Rust implementation of Pruning Radix Trie, originally by Wolf Gar
 
 [dependencies]
 compact_str = "0.7.0"
+
+[dev-dependencies]
 criterion = "0.4.0"
 lazy_static = "1.4.0"
 


### PR DESCRIPTION
This change moves criterion and lazy_static to dev-dependencies since they are only used in the benchmark.

This changes lowers the amount of dependencies from 83 to 10 on macOS.